### PR TITLE
Add Rate Limiting

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -116,3 +116,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# redis
+dump.rdb

--- a/server/conftest/env.js
+++ b/server/conftest/env.js
@@ -11,6 +11,7 @@ const exec = require("./exec")
 const prismaBinary = "./node_modules/.bin/prisma2"
 
 
+
 class PrismaTestEnvironment extends NodeEnvironment {
     constructor(config) {
         super(config)
@@ -25,17 +26,18 @@ class PrismaTestEnvironment extends NodeEnvironment {
 
         this.global.__PRISMA__ = prisma
 
-        process.env.DATABASE_URL = this.dbURL
-        this.global.process.env.DATABASE_URL = this.dbURL
+        const envVars = {
+            DATABASE_URL: this.dbURL,
+            PRISMA_BINARY: prismaBinary,
+            SENDGRID_SANDBOX: "enabled",
+            SNOWCLOUD_SANDBOX: "enabled",
+            DISABLE_RATE_LIMITING: "true"
+        }
 
-        process.env.PRISMA_BINARY = prismaBinary
-        this.global.process.env.PRISMA_BINARY = prismaBinary
-
-        process.env.SENDGRID_SANDBOX = "enabled"
-        this.global.process.env.SENDGRID_SANDBOX = "enabled"
-
-        process.env.SNOWCLOUD_SANDBOX = "enabled"
-        this.global.process.env.SNOWCLOUD_SANDBOX = "enabled"
+        for (const key in envVars) {
+            process.env[key] = envVars[key]
+            this.global.process.env[key] = envVars[key]
+        }
 
         await exec(`${prismaBinary} migrate reset --force`)
 

--- a/server/conftest/setup.js
+++ b/server/conftest/setup.js
@@ -1,1 +1,2 @@
 jest.mock("../utils/prisma", () => global.__PRISMA__)
+jest.mock("ioredis", () => jest.requireActual("ioredis-mock/jest"))

--- a/server/conftest/setupAfterEnv.js
+++ b/server/conftest/setupAfterEnv.js
@@ -13,6 +13,8 @@ beforeEach(async () => {
     for (let model of models) {
         await prisma[model].deleteMany()
     }
+
+    await redis.flushdb()
 })
 
 afterEach(() => {

--- a/server/conftest/setupAfterEnv.js
+++ b/server/conftest/setupAfterEnv.js
@@ -1,8 +1,8 @@
-const exec = require("./exec")
-
 jest.mock("../utils/email", () => jest.fn())
 
 const prisma = require("../utils/prisma")
+
+const redis = require("../utils/redis")
 
 beforeEach(async () => {
 
@@ -17,4 +17,8 @@ beforeEach(async () => {
 
 afterEach(() => {
     jest.clearAllMocks();
+})
+
+afterAll(async () => {
+    await redis.quit()
 })

--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,7 @@ require("dotenv").config()
 const Koa = require("koa")
 const bodyparser = require("koa-bodyparser")
 
+const rateLimit = require("./middleware/rateLimit")
 const authMiddleware = require("./middleware/auth")
 const { errorHandler, errorCatcher } = require("./middleware/error")
 const requireLogin = require("./middleware/requireLogin")
@@ -33,6 +34,8 @@ app.use(bodyparser({
 
 // Preliminary Authentication Middleware
 app.use(authMiddleware)
+
+app.use(rateLimit)
 
 // Unprotected Routes
 app.use(indexRoutes.routes())

--- a/server/middleware/rateLimit.js
+++ b/server/middleware/rateLimit.js
@@ -3,6 +3,11 @@ const ipaddr = require("ipaddr.js")
 const redis = require("../utils/redis")
 
 const rateLimit = async (ctx, next) => {
+    if (process.env.DISABLE_RATE_LIMITING) {
+        // Rate limit disabled for testing
+        return next()
+    }
+
     if (ctx.request.method === "OPTIONS") {
         // Ignore CORS preflight requests
         return next()

--- a/server/middleware/rateLimit.js
+++ b/server/middleware/rateLimit.js
@@ -1,0 +1,56 @@
+const ipaddr = require("ipaddr.js")
+
+const redis = require("../utils/redis")
+
+const rateLimit = async (ctx, next) => {
+    if (ctx.request.method === "OPTIONS") {
+        // Ignore CORS preflight requests
+        return next()
+    }
+
+    // Every minute is a new interval
+    const interval = Math.floor((new Date()).getUTCMinutes())
+
+    let key
+
+    if (ctx.user) {
+        // The user has logged in
+        // We can track them by their ID for ratelimiting purposes
+        key = `ratelimit:user:${ctx.user.id}:${interval}`
+    } else {
+        // Rely on their IP address instead
+
+        let ip = ctx.request.ip
+
+        if (process.env.NODE_ENV === "production") {
+            // We are behind nginx proxy
+            ip = ctx.request.headers["x-forwarded-for"].split(",")[0]
+        }
+
+        const parsedIp = ipaddr.parse(ip)
+
+        if (parsedIp.kind() === "ipv6") {
+            // Filter based on IPv6 /64
+            // (typically, each /64 is one network)
+
+            ip = parsedIp.parts.slice(0, 3).join(":") + "/64"
+        }
+
+        key = `ratelimit:ip:${ip}:${interval}`
+    }
+
+    const currentRequests = await redis.get(key)
+
+    if (currentRequests > 100) {
+        ctx.throw(429, "Too many requests")
+    }
+
+    console.log(`${key} has made ${currentRequests} requests`)
+
+    await redis.incr(key)
+    await redis.expire(key, 60)
+
+    await next()
+}
+
+module.exports = rateLimit

--- a/server/middleware/rateLimit.js
+++ b/server/middleware/rateLimit.js
@@ -3,8 +3,7 @@ const ipaddr = require("ipaddr.js")
 const redis = require("../utils/redis")
 
 const rateLimit = async (ctx, next) => {
-    if (process.env.DISABLE_RATE_LIMITING) {
-        // Rate limit disabled for testing
+    if (process.env.DISABLE_RATE_LIMITING === "true") {
         return next()
     }
 
@@ -51,8 +50,6 @@ const rateLimit = async (ctx, next) => {
     if (currentRequests > 100) {
         ctx.throw(429, "Too many requests")
     }
-
-    console.log(`${key} has made ${currentRequests} requests`)
 
     await redis.incr(key)
     await redis.expire(key, 60)

--- a/server/middleware/rateLimit.test.js
+++ b/server/middleware/rateLimit.test.js
@@ -1,0 +1,119 @@
+const request = require("supertest")
+
+const app = require("../index.js")
+
+const { loginUser } = require("../conftest/utils")
+
+describe("global ratelimit middleware", () => {
+    const OLD_ENV = process.env
+
+    beforeEach(() => {
+        process.env = { ...OLD_ENV }
+    })
+
+    afterAll(() => {
+        process.env = OLD_ENV
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks()
+        jest.useRealTimers()
+    })
+
+    it("allows a single request through", async () => {
+        process.env.DISABLE_RATE_LIMITING = "false"
+
+        const response = await request(app.callback())
+            .get("/")
+
+        expect(response.statusCode).toBe(200)
+    })
+
+    it("blocks more than 100 requests in one minute", async () => {
+        // Set the system time constant
+        jest.useFakeTimers()
+        jest.setSystemTime(new Date(Date.now()))
+
+        process.env.DISABLE_RATE_LIMITING = "false"
+
+        for (let i = 0; i < 101; i++) {
+            await request(app.callback())
+                .get("/")
+        }
+
+        const response = await request(app.callback())
+            .get("/")
+
+        expect(response.statusCode).toBe(429)
+    })
+
+    it("has separate quotas for different tokens", async () => {
+        const evilUser = await loginUser({ email: "evil@thesatanictemple.com" })
+        const goodUser = await loginUser({ email: "good@example.com" })
+
+        process.env.DISABLE_RATE_LIMITING = "false"
+
+        for (let i = 0; i < 101; i++) {
+            await request(app.callback())
+                .get("/")
+                .set("Authorization", `Bearer ${evilUser.token}`)
+        }
+
+        const response = await request(app.callback())
+            .get("/")
+            .set("Authorization", `Bearer ${goodUser.token}`)
+
+        expect(response.statusCode).toBe(200)
+    })
+
+    it("has separate quotas for different IPv4 addresses", async () => {
+        process.env.DISABLE_RATE_LIMITING = "false"
+        process.env.BEHIND_PROXY = "true"
+
+        for (let i = 0; i < 101; i++) {
+            await request(app.callback())
+                .get("/")
+                .set("X-Forwarded-For", "6.6.6.6")
+        }
+
+        const response = await request(app.callback())
+            .get("/")
+            .set("X-Forwarded-For", "1.1.1.1")
+
+        expect(response.statusCode).toBe(200)
+    })
+
+    it("has separate quotas for different IPv6 addresses", async () => {
+        process.env.DISABLE_RATE_LIMITING = "false"
+        process.env.BEHIND_PROXY = "true"
+
+        for (let i = 0; i < 101; i++) {
+            await request(app.callback())
+                .get("/")
+                .set("X-Forwarded-For", "666:666:420:420::1")
+        }
+
+        const response = await request(app.callback())
+            .get("/")
+            .set("X-Forwarded-For", "600D::1")
+
+        expect(response.statusCode).toBe(200)
+    })
+
+    it("treats IPv6 /64 blocks as the same IP", async () => {
+        process.env.DISABLE_RATE_LIMITING = "false"
+        process.env.BEHIND_PROXY = "true"
+
+        for (let i = 0; i < 101; i++) {
+            await request(app.callback())
+                .get("/")
+                .set("X-Forwarded-For", "666:666:420:420::1")
+        }
+
+        const response = await request(app.callback())
+            .get("/")
+            .set("X-Forwarded-For", "666:666:420:420::2")
+
+        expect(response.statusCode).toBe(429)
+    })
+})

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -25,6 +25,7 @@
         "uuid": "^8.3.2"
       },
       "devDependencies": {
+        "ioredis-mock": "^5.6.0",
         "jest": "^27.0.6",
         "nodemon": "^2.0.12",
         "pg": "^8.6.0",
@@ -2804,6 +2805,32 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fengari": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.4.tgz",
+      "integrity": "sha512-6ujqUuiIYmcgkGz8MGAdERU57EIluGGPSUgGPTsco657EHa+srq0S3/YUl/r9kx1+D+d4rGfYObd+m8K22gB1g==",
+      "dev": true,
+      "dependencies": {
+        "readline-sync": "^1.4.9",
+        "sprintf-js": "^1.1.1",
+        "tmp": "^0.0.33"
+      }
+    },
+    "node_modules/fengari-interop": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/fengari-interop/-/fengari-interop-0.1.2.tgz",
+      "integrity": "sha512-8iTvaByZVoi+lQJhHH9vC+c/Yaok9CwOqNQZN6JrVpjmWwW4dDkeblBXhnHC+BoI6eF4Cy5NKW3z6ICEjvgywQ==",
+      "dev": true,
+      "peerDependencies": {
+        "fengari": "^0.1.0"
+      }
+    },
+    "node_modules/fengari/node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+      "dev": true
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3333,6 +3360,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis-mock": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-5.6.0.tgz",
+      "integrity": "sha512-Ow+tyKdijg/gA2gSEv7lq8dLp6bO7FnwDXbJ9as37NF23XNRGMLzBc7ITaqMydfrbTodWnLcE2lKEaBs7SBpyA==",
+      "dev": true,
+      "dependencies": {
+        "fengari": "^0.1.4",
+        "fengari-interop": "^0.1.2",
+        "lodash": "^4.17.21",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "ioredis": "4.x",
+        "redis-commands": "1.x"
       }
     },
     "node_modules/ioredis/node_modules/debug": {
@@ -5668,6 +5714,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/p-cancelable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
@@ -6203,6 +6258,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/redis-commands": {
@@ -6776,6 +6840,18 @@
       "dependencies": {
         "inherits": "^2.0.4",
         "readable-stream": "2 || 3"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/tmpl": {
@@ -9482,6 +9558,32 @@
         "bser": "2.1.1"
       }
     },
+    "fengari": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/fengari/-/fengari-0.1.4.tgz",
+      "integrity": "sha512-6ujqUuiIYmcgkGz8MGAdERU57EIluGGPSUgGPTsco657EHa+srq0S3/YUl/r9kx1+D+d4rGfYObd+m8K22gB1g==",
+      "dev": true,
+      "requires": {
+        "readline-sync": "^1.4.9",
+        "sprintf-js": "^1.1.1",
+        "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
+          "dev": true
+        }
+      }
+    },
+    "fengari-interop": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/fengari-interop/-/fengari-interop-0.1.2.tgz",
+      "integrity": "sha512-8iTvaByZVoi+lQJhHH9vC+c/Yaok9CwOqNQZN6JrVpjmWwW4dDkeblBXhnHC+BoI6eF4Cy5NKW3z6ICEjvgywQ==",
+      "dev": true,
+      "requires": {}
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -9893,6 +9995,18 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
+      }
+    },
+    "ioredis-mock": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/ioredis-mock/-/ioredis-mock-5.6.0.tgz",
+      "integrity": "sha512-Ow+tyKdijg/gA2gSEv7lq8dLp6bO7FnwDXbJ9as37NF23XNRGMLzBc7ITaqMydfrbTodWnLcE2lKEaBs7SBpyA==",
+      "dev": true,
+      "requires": {
+        "fengari": "^0.1.4",
+        "fengari-interop": "^0.1.2",
+        "lodash": "^4.17.21",
+        "standard-as-callback": "^2.1.0"
       }
     },
     "ipaddr.js": {
@@ -11675,6 +11789,12 @@
         "word-wrap": "~1.2.3"
       }
     },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
     "p-cancelable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
@@ -12072,6 +12192,12 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw==",
+      "dev": true
     },
     "redis-commands": {
       "version": "1.7.0",
@@ -12507,6 +12633,15 @@
       "requires": {
         "inherits": "^2.0.4",
         "readable-stream": "2 || 3"
+      }
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
       }
     },
     "tmpl": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -13,6 +13,8 @@
         "@koa/router": "^10.0.0",
         "@prisma/client": "^2.28.0",
         "dotenv": "^10.0.0",
+        "ioredis": "^4.27.7",
+        "ipaddr.js": "^2.0.1",
         "jsonwebtoken": "^8.5.1",
         "koa": "^2.13.1",
         "koa-bodyparser": "^4.3.0",
@@ -2093,6 +2095,14 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2423,6 +2433,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "node_modules/denque": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==",
+      "engines": {
+        "node": ">=0.10"
+      }
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -3291,6 +3309,60 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
       "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
       "dev": true
+    },
+    "node_modules/ioredis": {
+      "version": "4.27.7",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.27.7.tgz",
+      "integrity": "sha512-lqvFFmUyGIHlrNyDvBoakzy1+ioJzNyoP6CP97GWtdTjWq9IOAnv6l0HUTsqhvd/z9etGgtrDHZ4kWCMAwNkug==",
+      "dependencies": {
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.1",
+        "denque": "^1.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isarguments": "^3.1.0",
+        "p-map": "^2.1.0",
+        "redis-commands": "1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
+    },
+    "node_modules/ioredis/node_modules/debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ioredis/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
+      "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==",
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -5124,10 +5196,25 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "node_modules/lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
@@ -5629,6 +5716,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -6110,6 +6205,30 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/registry-auth-token": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
@@ -6362,6 +6481,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "node_modules/statuses": {
       "version": "1.5.0",
@@ -8787,6 +8911,11 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "cluster-key-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.0.tgz",
+      "integrity": "sha512-2Nii8p3RwAPiFwsnZvukotvow2rIHM+yQ6ZcBXGHdniadkYGZYiGmkHJIbZPIV9nfv7m/U1IPMVVcAhoWFeklw=="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -9072,6 +9201,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
+    "denque": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
     },
     "depd": {
       "version": "2.0.0",
@@ -9727,6 +9861,44 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
       "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
       "dev": true
+    },
+    "ioredis": {
+      "version": "4.27.7",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.27.7.tgz",
+      "integrity": "sha512-lqvFFmUyGIHlrNyDvBoakzy1+ioJzNyoP6CP97GWtdTjWq9IOAnv6l0HUTsqhvd/z9etGgtrDHZ4kWCMAwNkug==",
+      "requires": {
+        "cluster-key-slot": "^1.1.0",
+        "debug": "^4.3.1",
+        "denque": "^1.1.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isarguments": "^3.1.0",
+        "p-map": "^2.1.0",
+        "redis-commands": "1.7.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0",
+        "standard-as-callback": "^2.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "ipaddr.js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.0.1.tgz",
+      "integrity": "sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng=="
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -11134,10 +11306,25 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
     },
     "lodash.isboolean": {
       "version": "3.0.3",
@@ -11518,6 +11705,11 @@
         "p-limit": "^2.2.0"
       }
     },
+    "p-map": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -11881,6 +12073,24 @@
         "picomatch": "^2.2.1"
       }
     },
+    "redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "requires": {
+        "redis-errors": "^1.0.0"
+      }
+    },
     "registry-auth-token": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.2.1.tgz",
@@ -12081,6 +12291,11 @@
       "requires": {
         "escape-string-regexp": "^2.0.0"
       }
+    },
+    "standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="
     },
     "statuses": {
       "version": "1.5.0",

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,8 @@
     "@koa/router": "^10.0.0",
     "@prisma/client": "^2.28.0",
     "dotenv": "^10.0.0",
+    "ioredis": "^4.27.7",
+    "ipaddr.js": "^2.0.1",
     "jsonwebtoken": "^8.5.1",
     "koa": "^2.13.1",
     "koa-bodyparser": "^4.3.0",

--- a/server/package.json
+++ b/server/package.json
@@ -28,6 +28,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
+    "ioredis-mock": "^5.6.0",
     "jest": "^27.0.6",
     "nodemon": "^2.0.12",
     "pg": "^8.6.0",

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -12,7 +12,7 @@ const router = new Router()
 
 
 const handleRateLimit = async (ctx, score) => {
-    if (process.env.DISABLE_RATE_LIMITING) {
+    if (process.env.DISABLE_RATE_LIMITING === "true") {
         return
     }
 
@@ -27,8 +27,6 @@ const handleRateLimit = async (ctx, score) => {
     }
 
     await redis.incrby(key, score)
-
-    console.log(`${key} has score ${parseInt(currentScore) + score} in interval ${interval}`)
 
     await redis.expire(key, 24 * 60 * 60)
 }

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -12,6 +12,10 @@ const router = new Router()
 
 
 const handleRateLimit = async (ctx, score) => {
+    if (process.env.DISABLE_RATE_LIMITING) {
+        return
+    }
+
     const interval = Math.floor((new Date()).getUTCDate())
 
     const key = `authRateLimit:${ctx.ratelimitIdentifier}:${interval}`

--- a/server/routes/auth.test.js
+++ b/server/routes/auth.test.js
@@ -403,7 +403,8 @@ describe("auth rate limiting", () => {
     })
 
     afterEach(() => {
-        jest.clearAllMocks();
+        jest.clearAllMocks()
+        jest.useRealTimers()
     })
 
     it("allows a single signup attempt", async () => {
@@ -451,5 +452,48 @@ describe("auth rate limiting", () => {
             .send({ email: "final@example.com" })
 
         expect(response.statusCode).toBe(429)
+    })
+
+    it("allows a single signup attempt again", async () => {
+        // This is to make sure that the above ratelimiting tests
+        // don't interfere with each other
+
+        process.env.DISABLE_RATE_LIMITING = "false"
+
+        const response = await request(app.callback())
+            .post("/auth/signup")
+            .type("form")
+            .send({ name: "Test User", email: "first@example.com", password: "password" })
+
+        expect(response.statusCode).toBe(200)
+    })
+
+    it("resets the quota after one day", async () => {
+        jest.useFakeTimers()
+
+        process.env.DISABLE_RATE_LIMITING = "false"
+
+        for (let i = 0; i < 10; ++i) {
+            await request(app.callback())
+                .post("/auth/signup")
+                .type("form")
+                .send({ name: "Test User", email: i + "@example.com", password: "password" })
+        }
+
+        const response = await request(app.callback())
+            .post("/auth/signup")
+            .type("form")
+            .send({ name: "Test User", email: "first@example.com", password: "password" })
+
+        expect(response.statusCode).toBe(429)
+
+        jest.setSystemTime(new Date(Date.now() + (24 * 60 * 60 * 1000)))
+
+        const dayLaterResponse = await request(app.callback())
+            .post("/auth/signup")
+            .type("form")
+            .send({ name: "Test User", email: "second@example.com", password: "password" })
+
+        expect(dayLaterResponse.statusCode).toBe(200)
     })
 })

--- a/server/routes/auth.test.js
+++ b/server/routes/auth.test.js
@@ -389,3 +389,67 @@ describe("account deletion", () => {
         expect(dbUser).not.toBe(null)
     })
 })
+
+
+describe("auth rate limiting", () => {
+    const OLD_ENV = process.env
+
+    beforeEach(() => {
+        process.env = { ...OLD_ENV }
+    })
+
+    afterAll(() => {
+        process.env = OLD_ENV
+    })
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    })
+
+    it("allows a single signup attempt", async () => {
+        process.env.DISABLE_RATE_LIMITING = "false"
+
+        const response = await request(app.callback())
+            .post("/auth/signup")
+            .type("form")
+            .send({ name: "Test User", email: "first@example.com", password: "password" })
+
+        expect(response.statusCode).toBe(200)
+    })
+
+    it("does not allow more than 10 signups from the same IP", async () => {
+        process.env.DISABLE_RATE_LIMITING = "false"
+
+        for (let i = 0; i < 10; ++i) {
+            await request(app.callback())
+                .post("/auth/signup")
+                .type("form")
+                .send({ name: "Test User", email: i + "@example.com", password: "password" })
+        }
+
+        const response = await request(app.callback())
+            .post("/auth/signup")
+            .type("form")
+            .send({ name: "Test User", email: "first@example.com", password: "password" })
+
+        expect(response.statusCode).toBe(429)
+    })
+
+    it("does not allow more than 2 password resets from the same IP", async () => {
+        process.env.DISABLE_RATE_LIMITING = "false"
+
+        for (let i = 0; i < 2; ++i) {
+            await request(app.callback())
+                .post("/auth/reset")
+                .type("form")
+                .send({ email: i + "@example.com" })
+        }
+
+        const response = await request(app.callback())
+            .post("/auth/reset")
+            .type("form")
+            .send({ email: "final@example.com" })
+
+        expect(response.statusCode).toBe(429)
+    })
+})

--- a/server/utils/redis.js
+++ b/server/utils/redis.js
@@ -1,0 +1,5 @@
+const Redis = require("ioredis")
+
+const redis = new Redis()
+
+module.exports = redis

--- a/server/utils/redis.js
+++ b/server/utils/redis.js
@@ -1,5 +1,5 @@
 const Redis = require("ioredis")
 
-const redis = new Redis()
+const redis = new Redis(process.env.REDIS_URL)
 
 module.exports = redis


### PR DESCRIPTION
Adds two types of rate limiting:
* Global cap of 100 requests per minute, intended to stop automated users from scraping or spamming the platform.
* Separate cap of 100 'points' per day for auth routes. Auth routes consume a varying number of 'points'. Intended to stop malicious users from creating excessive accounts, sending nuisance password change emails, etc.
  * 0 points: `/auth/status`
  * 1 point: `/auth/login`, `/auth/verify`, `/auth/refresh`, `/auth/delete`
  * 10 points: `/auth/signup`, `/auth/email`, `/auth/password`
  * 40 points: `/auth/reset`

These are implemented in Redis. As such, a Redis server is now required to deploy Flowspace. The implementation follows the general structure laid out in [this Redis Labs guide](https://redislabs.com/redis-best-practices/basic-rate-limiting/). Each minute on the clock has a separate counter for each client's API requests.

If a client is logged in with a token, their user ID is used as their identifier. Otherwise, their IP address will be used as their identifier. If this is an IPv6 address, the last four parts will be removed, i.e., clients will be identified by their /64.

This PR also adds the following HTTP headers to all responses. These reference the global cap, not the auth cap.

| Header | Value |
| --- | --- |
| `X-RateLimit-Limit` | number of allowed requests per interval (100) |
| `X-RateLimit-Remaining` | number of remaining requests allowed in this interval |
| `X-RateLimit-Reset` | unix timestamp at which the rate limit resets (1 minute from now) |
| `X-RateLimit-Reset-After` | seconds until the rate limit resets (60) |